### PR TITLE
Add support for .netconfig.user files

### DIFF
--- a/src/Config/AggregateConfig.cs
+++ b/src/Config/AggregateConfig.cs
@@ -13,16 +13,16 @@ namespace DotNetConfig
         public List<Config> Files { get; }
 
         public override void AddBoolean(string section, string? subsection, string variable, bool value)
-            => Files.First().AddBoolean(section, subsection, variable, value);
+            => Files.First(x => x.Level == null).AddBoolean(section, subsection, variable, value);
 
         public override void AddDateTime(string section, string? subsection, string variable, DateTime value)
-            => Files.First().AddDateTime(section, subsection, variable, value);
+            => Files.First(x => x.Level == null).AddDateTime(section, subsection, variable, value);
 
         public override void AddNumber(string section, string? subsection, string variable, long value)
-            => Files.First().AddNumber(section, subsection, variable, value);
+            => Files.First(x => x.Level == null).AddNumber(section, subsection, variable, value);
 
         public override void AddString(string section, string? subsection, string variable, string value)
-            => Files.First().AddString(section, subsection, variable, value);
+            => Files.First(x => x.Level == null).AddString(section, subsection, variable, value);
 
         public override IEnumerable<ConfigEntry> GetAll(string section, string? subsection, string variable, string? valueRegex)
             => Files.SelectMany(x => x.GetAll(section, subsection, variable, valueRegex));
@@ -31,34 +31,34 @@ namespace DotNetConfig
             => Files.SelectMany(x => x.GetRegex(nameRegex, valueRegex));
 
         public override void RemoveSection(string section, string? subsection = null)
-            => Files.First().RemoveSection(section, subsection);
+            => Files.First(x => x.Level == null).RemoveSection(section, subsection);
 
         public override void RenameSection(string oldSection, string? oldSubsection, string newSection, string? newSubsection)
-            => Files.First().RenameSection(oldSection, oldSubsection, newSection, newSubsection);
+            => Files.First(x => x.Level == null).RenameSection(oldSection, oldSubsection, newSection, newSubsection);
 
         public override void SetAllBoolean(string section, string? subsection, string variable, bool value, string? valueRegex)
-            => Files.First().SetAllBoolean(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetAllBoolean(section, subsection, variable, value, valueRegex);
 
         public override void SetAllDateTime(string section, string? subsection, string variable, DateTime value, string? valueRegex)
-            => Files.First().SetAllDateTime(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetAllDateTime(section, subsection, variable, value, valueRegex);
 
         public override void SetAllNumber(string section, string? subsection, string variable, long value, string? valueRegex)
-            => Files.First().SetAllNumber(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetAllNumber(section, subsection, variable, value, valueRegex);
 
         public override void SetAllString(string section, string? subsection, string variable, string value, string? valueRegex)
-            => Files.First().SetAllString(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetAllString(section, subsection, variable, value, valueRegex);
 
         public override void SetBoolean(string section, string? subsection, string variable, bool value, string? valueRegex)
-            => Files.First().SetBoolean(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetBoolean(section, subsection, variable, value, valueRegex);
 
         public override void SetDateTime(string section, string? subsection, string variable, DateTime value, string? valueRegex)
-            => Files.First().SetDateTime(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetDateTime(section, subsection, variable, value, valueRegex);
 
         public override void SetNumber(string section, string? subsection, string variable, long value, string? valueRegex)
-            => Files.First().SetNumber(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetNumber(section, subsection, variable, value, valueRegex);
 
         public override void SetString(string section, string? subsection, string variable, string value, string? valueRegex)
-            => Files.First().SetString(section, subsection, variable, value, valueRegex);
+            => Files.First(x => x.Level == null).SetString(section, subsection, variable, value, valueRegex);
 
         public override bool TryGetBoolean(string section, string? subsection, string variable, out bool value)
         {
@@ -109,10 +109,10 @@ namespace DotNetConfig
         }
 
         public override void Unset(string section, string? subsection, string variable)
-            => Files.First().Unset(section, subsection, variable);
+            => Files.First(x => x.Level == null).Unset(section, subsection, variable);
 
         public override void UnsetAll(string section, string? subsection, string variable, string? valueRegex)
-            => Files.First().UnsetAll(section, subsection, variable, valueRegex);
+            => Files.First(x => x.Level == null).UnsetAll(section, subsection, variable, valueRegex);
 
         protected override IEnumerable<ConfigEntry> GetEntries() => Files.SelectMany(x => x);
     }

--- a/src/Config/Config.csproj
+++ b/src/Config/Config.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>APIs for handling dotnet-config compatible settings for any dotnet tool.</Description>
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Metadata" Version="0.1.4" PrivateAssets="all" />
-    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="docfx.console" Version="2.56.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/Config/ConfigDocument.cs
+++ b/src/Config/ConfigDocument.cs
@@ -23,6 +23,8 @@ namespace DotNetConfig
                     level = ConfigLevel.Global;
                 else if (filePath == Config.SystemLocation)
                     level = ConfigLevel.System;
+                else if (filePath.EndsWith(Config.UserExtension, StringComparison.Ordinal))
+                    level = ConfigLevel.Local;
             }
 
             Level = level;

--- a/src/Config/ConfigExtensions.cs
+++ b/src/Config/ConfigExtensions.cs
@@ -917,6 +917,18 @@ namespace DotNetConfig
         public static void RenameSection(this Config config, string oldSection, string newSection, ConfigLevel level)
             => Write(config, level, x => config.RenameSection(oldSection, null, newSection, null));
 
+        /// <summary>
+        /// Renames a section.
+        /// </summary>
+        /// <param name="config">The configuration to operate on.</param>
+        /// <param name="oldSection">The old section name to rename.</param>
+        /// <param name="oldSubsection">The optional old subsection to rename.</param>
+        /// <param name="newSection">The new section name to use.</param>
+        /// <param name="newSubsection">The optional new subsection to use.</param>
+        /// <param name="level">The configuration level to operate on.</param>
+        public static void RenameSection(this Config config, string oldSection, string? oldSubsection, string newSection, string? newSubsection, ConfigLevel level)
+            => Write(config, level, x => config.RenameSection(oldSection, oldSubsection, newSection, newSubsection));
+
         static void Write(Config config, ConfigLevel level, Action<Config> action)
         {
             if (config.Level == level)

--- a/src/Config/ConfigLevel.cs
+++ b/src/Config/ConfigLevel.cs
@@ -8,6 +8,13 @@ namespace DotNetConfig
     public enum ConfigLevel
     {
         /// <summary>
+        /// Use a <c>.netconfig.user</c> file, instead of the default <c>.netconfig</c>, 
+        /// which allows separating local-only settings from potentially 
+        /// team-wide configuration files that can be checked-in source control.
+        /// </summary>
+        Local,
+
+        /// <summary>
         /// The global ~/.netconfig for the current user, from the 
         /// <see cref="Environment.SpecialFolder.UserProfile"/> location.
         /// </summary>


### PR DESCRIPTION
This allows to better separate local-only settings from potentially team-wide settings that can be commited to source control.

These files can be written to by using the new `ConfigLevel.Local` enum value for the mutating overloads receiving a level.

The overriding is possible at all the levels where the `.netconfig` is also valid, which provides the maximum flexibility.