### PR TITLE
Fix inclusion of build metadata in package id in non-main builds

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -28,15 +28,16 @@
     <PropertyGroup>
       <GitBranch>$(GitBranch.Replace('/', '-'))</GitBranch>
       <!-- We don't build stable versions from non-master branches. But when the version came from the branch, we leave it as-is. -->
-      <GitSemVerDashLabel Condition="'$(GitBranch)' != 'master' and '$(GitSemVerDashLabel)' == '' and '$(GitSemVerSource)' != 'Branch'">-$(GitBranch)</GitSemVerDashLabel>
+      <GitSemVerDashLabel Condition="'$(GitBranch)' != 'master'">$(GitSemVerDashLabel)-$(GitBranch)</GitSemVerDashLabel>
+
       <IncludeBuildMetadata>$(PR)</IncludeBuildMetadata>
       <!-- Build metadata always present for non-master branches, unless the existing label matches the branch.
            For a versioned branch, it doesn't make sense either. -->
       <IncludeBuildMetadata Condition="'$(GitBranch)' != 'master' and '$(GitSemVerSource)' != 'Branch' and '$(GitSemVerDashLabel)' != '-$(GitBranch)'">true</IncludeBuildMetadata>
     </PropertyGroup>
 
+
     <ItemGroup>
-      <BuildMetadata Include="$(GitBranch)" />
       <BuildMetadata Condition="'$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != ''"
                      Include="pr.$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)"/>
       <BuildMetadata Include="sha.$(GitCommit)" Condition="'$(GitCommit)' != ''"/>
@@ -45,7 +46,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <BuildMetadataLabel>@(VersionMetadata -> '%(Identity)', '-')</BuildMetadataLabel>
+      <BuildMetadataLabel>@(BuildMetadata -> '%(Identity)', '-')</BuildMetadataLabel>
       <BuildMetadataPlusLabel Condition="'$(BuildMetadataLabel)' != ''">+$(BuildMetadataLabel)</BuildMetadataPlusLabel>
 
       <GitSemVerDashLabel Condition="'$(GitSemVerDashLabel)' != '' and '$(GitCommits)' != '0'">$(GitSemVerDashLabel).$(GitCommits)</GitSemVerDashLabel>


### PR DESCRIPTION
There was an error in the way we were including the metadata, so we were not getting it at all, even for non-main branches (which should always have it, to disambiguate when testing feature branches or PRs from packages built by CI).