### PR TITLE
Get normalized and resolved relative paths from config

### DIFF
--- a/src/Config/AggregateConfig.cs
+++ b/src/Config/AggregateConfig.cs
@@ -30,6 +30,9 @@ namespace DotNetConfig
         public override IEnumerable<ConfigEntry> GetRegex(string nameRegex, string? valueRegex = null)
             => Files.SelectMany(x => x.GetRegex(nameRegex, valueRegex));
 
+        public override string? GetNormalizedPath(string section, string? subsection, string variable)
+            => Files.Select(config => config.GetNormalizedPath(section, subsection, variable)).Where(x => x != null).FirstOrDefault();
+
         public override void RemoveSection(string section, string? subsection = null)
             => Files.First(x => x.Level == null).RemoveSection(section, subsection);
 

--- a/src/Config/Config.cs
+++ b/src/Config/Config.cs
@@ -94,7 +94,7 @@ namespace DotNetConfig
                 if (File.Exists(file))
                     configs.Files.Add(new FileConfig(file));
 
-                file = file[..^4];
+                file = Path.Combine(dir.FullName, FileName);
                 if (File.Exists(file))
                     configs.Files.Add(new FileConfig(file));
 
@@ -206,6 +206,17 @@ namespace DotNetConfig
         /// <param name="nameRegex">Regular expression to match against the key (section plus subsection and variable name).</param>
         /// <param name="valueRegex">Optional regular expression to match against the variable values.</param>
         public abstract IEnumerable<ConfigEntry> GetRegex(string nameRegex, string? valueRegex = null);
+
+        /// <summary>
+        /// Gets a string variable and applies path normalization to it, resolving 
+        /// relative paths and normalizing directory separator characters to the 
+        /// current platform.
+        /// </summary>
+        /// <param name="section">The section containing the variable.</param>
+        /// <param name="subsection">Optional subsection containing the variable.</param>
+        /// <param name="variable">The variable to retrieve as a resolved path.</param>
+        /// <returns><see langword="true"/> if the value was found, <see langword="false"/> otherwise.</returns>
+        public abstract string? GetNormalizedPath(string section, string? subsection, string variable);
 
         /// <summary>
         /// Sets the value of a variable in the given section and optional subsection.

--- a/src/Config/ConfigExtensions.cs
+++ b/src/Config/ConfigExtensions.cs
@@ -228,6 +228,18 @@ namespace DotNetConfig
             => config.GetString(section, null, variable);
 
         /// <summary>
+        /// Gets a string variable and applies path normalization to it, resolving 
+        /// relative paths and normalizing directory separator characters to the 
+        /// current platform.
+        /// </summary>
+        /// <param name="config">The configuration to get the value from.</param>
+        /// <param name="section">The section containing the variable.</param>
+        /// <param name="variable">The variable to retrieve as a resolved path.</param>
+        /// <returns><see langword="true"/> if the value was found, <see langword="false"/> otherwise.</returns>
+        public static string? GetNormalizedPath(this Config config, string section, string variable)
+            => config.GetNormalizedPath(section, null, variable);
+
+        /// <summary>
         /// Gets all values from a multi-valued variable from the given section.
         /// </summary>
         /// <param name="config">The configuration to get the values from.</param>

--- a/src/Config/ConfigSection.cs
+++ b/src/Config/ConfigSection.cs
@@ -55,6 +55,15 @@ namespace DotNetConfig
         public IEnumerable<ConfigEntry> GetAll(string variable, string? valueRegex = null) => Config.GetAll(Section, Subsection, variable, valueRegex);
 
         /// <summary>
+        /// Gets a string variable and applies path normalization to it, resolving 
+        /// relative paths and normalizing directory separator characters to the 
+        /// current platform.
+        /// </summary>
+        /// <param name="variable">The variable to retrieve as a resolved path.</param>
+        /// <returns><see langword="true"/> if the value was found, <see langword="false"/> otherwise.</returns>
+        public string? GetNormalizedPath(string variable) => Config.GetNormalizedPath(Section, Subsection, variable);
+
+        /// <summary>
         /// Sets the value of all matching variables in the given section and optional subsection.
         /// </summary>
         /// <param name="variable">The variable to assign.</param>

--- a/src/Config/FileConfig.cs
+++ b/src/Config/FileConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace DotNetConfig
@@ -50,6 +51,17 @@ namespace DotNetConfig
 
         public override IEnumerable<ConfigEntry> GetRegex(string nameRegex, string? valueRegex = null)
             => doc.GetAll(nameRegex, valueRegex);
+
+        public override string? GetNormalizedPath(string section, string? subsection, string variable)
+        {
+            if (!TryGetString(section, subsection, variable, out var value))
+                return null;
+
+            if (Path.IsPathRooted(value))
+                return new FileInfo(value).FullName;
+
+            return new FileInfo(Path.Combine(Path.GetDirectoryName(FilePath), value)).FullName;
+        }
 
         public override void RemoveSection(string section, string? subsection)
         {


### PR DESCRIPTION
Allow resolving file path variable values relative to their declaring file at all supported levels. The normalization is performed using the `FileInfo.FullName` so that it will normalize path separators too as well as relative path.

Works for files and directories.

Fixes #5