### PR TITLE
Run CI validation via GH actions for speed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+name: pull-request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.100-preview.7.20366.6
+      - name: Test 🔧
+        run: dotnet test
+
+  macOS:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.100-preview.7.20366.6
+      - name: Test 🔧
+        run: dotnet test


### PR DESCRIPTION
We may drop these two platforms from AzDO eventually.