### PR TITLE
🖐 Add native .NET5 support to dotnet-config tool

### DIFF
--- a/src/Config.Tool/Config.Tool.csproj
+++ b/src/Config.Tool/Config.Tool.csproj
@@ -4,7 +4,7 @@
     <Description>A global tool for managing hierarchical configurations for dotnet tools, using git config format.</Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
 
     <AssemblyName>dotnet-config</AssemblyName>
@@ -14,6 +14,11 @@
     <ToolCommandName>dotnet-config</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <Nullable>enable</Nullable>
+    <!-- Disable warning about using AsSpan instead of range index on string since it's NET5 only -->
+    <NoWarn>$(NoWarn);CA1831</NoWarn>
+
+    <!-- This causes (random?) build failures inside VS but works fine in dotnet build -->
+    <DisableStrongNamer Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</DisableStrongNamer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Config.Tool/Program.cs
+++ b/src/Config.Tool/Program.cs
@@ -302,7 +302,7 @@ namespace DotNetConfig
                     if (!Config.Build(path).TryGetString("config", null, "editor", out var editor))
                     {
                         var cmd = Environment.OSVersion.Platform == PlatformID.Unix ? "which" : "where";
-                        editor = Process.Start(new ProcessStartInfo(cmd, "code") { RedirectStandardOutput = true }).StandardOutput.ReadLine() ?? "";
+                        editor = Process.Start(new ProcessStartInfo(cmd, "code") { RedirectStandardOutput = true })?.StandardOutput.ReadLine() ?? "";
                     }
 
                     var configFile = config.FilePath;

--- a/src/Config.Tool/Properties/.gitignore
+++ b/src/Config.Tool/Properties/.gitignore
@@ -1,0 +1,1 @@
+launchSettings.json

--- a/src/Config.Tool/Properties/launchSettings.json
+++ b/src/Config.Tool/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Config.Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "list"
-    }
-  }
-}


### PR DESCRIPTION
This allows running the tool on environments that have just .net5 installed.