### PR TITLE
☝ Ensure files are read only once when building Config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,89 @@
-﻿[*.cs]
+# EditorConfig is awesome:http://EditorConfig.org
 
-# IDE1006: Naming Styles
-dotnet_diagnostic.IDE1006.severity = none
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,msbuildproj,props,targets}]
+indent_size = 2
+
+# Xml config files
+[*.{ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# YAML files
+[*.{yaml,yml}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# CSharp code style settings:
+
+# IDE0040: Add accessibility modifiers
+dotnet_style_require_accessibility_modifiers = omit_if_default:error
+
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = error
+
+[*.cs]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have an expression-body
+csharp_style_expression_bodied_methods = true:none
+csharp_style_expression_bodied_constructors = true:none
+csharp_style_expression_bodied_operators = true:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true

--- a/src/Config.Tests/.editorconfig
+++ b/src/Config.Tests/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = none

--- a/src/Config.Tests/ConfigTests.cs
+++ b/src/Config.Tests/ConfigTests.cs
@@ -38,6 +38,26 @@ namespace DotNetConfig.Tests
         }
 
         [Fact]
+        public void when_reading_hierarchical_from_file_reads_system_once()
+        {
+            Config.SystemLocation = Path.Combine(Directory.GetCurrentDirectory(), "Content", ".netconfig");
+
+            var config = Config.Build(Path.Combine(Directory.GetCurrentDirectory(), "Content", "local", ".netconfig"));
+
+            Assert.True(config.GetBoolean("core", "local"));
+            Assert.True(config.GetBoolean("core", "parent"));
+
+            var section = config.GetSection("core");
+
+            Assert.True(section.GetBoolean("local"));
+            Assert.True(section.GetBoolean("parent"));
+            Assert.True(section.GetBoolean("global"));
+
+            // Reads the system.netconfig only once, even if the file is in a subfolder
+            Assert.Single(config.GetAll("core", "parent"));
+        }
+
+        [Fact]
         public void can_read_hierarchical_from_root_file()
         {
             var config = Config.Build("C:\\.netconfig");

--- a/src/Config/Config.cs
+++ b/src/Config/Config.cs
@@ -99,7 +99,9 @@ namespace DotNetConfig
                     configs.Files.Add(new FileConfig(file));
 
                 file = Path.Combine(dir.FullName, FileName);
-                if (File.Exists(file))
+                if (File.Exists(file) &&
+                    !GlobalLocation.Equals(file, StringComparison.OrdinalIgnoreCase) &&
+                    !SystemLocation.Equals(file, StringComparison.OrdinalIgnoreCase))
                     configs.Files.Add(new FileConfig(file));
 
                 dir = dir.Parent;


### PR DESCRIPTION
We skip loading both System and Global files when traversing directories up, so they are loaded predictably last, even for the case where they end up showing up in the hierarchy walking (i.e. when an app saves to %LocalAppData% too).

Fixes #31