### PR TITLE
🔄 dotnet-file sync

### DIFF
--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -11,7 +11,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
-  changelog:
+  sync:
     runs-on: windows-latest
     steps:
       - name: 🔍 GH_TOKEN
@@ -34,7 +34,7 @@ jobs:
           dotnet gcm store --protocol=https --host=github.com --username=$env:GITHUB_ACTOR --password=$env:GH_TOKEN
           gh auth status
 
-          dotnet tool update -g dotnet-file --no-cache --add-source https://pkg.kzu.io/index.json --version 42.42.42-main.75
+          dotnet tool update -g dotnet-file
           dotnet file sync -c:$env:TEMP\dotnet-file.md
           if (test-path $env:TEMP\dotnet-file.md) {
             echo 'CHANGES<<EOF' >> $env:GITHUB_ENV
@@ -50,9 +50,9 @@ jobs:
         with:
           base: main
           branch: dotnet-file-sync
-          commit-message: 🔄 dotnet-file sync
+          commit-message: Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
-          title: "🔄 dotnet-file sync"
+          title: "Bump files with dotnet-file sync"
           body: ${{ env.CHANGES }}
           token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/sponsors.ps1
+++ b/.github/workflows/sponsors.ps1
@@ -5,6 +5,8 @@ if ($author -eq $null) {
     throw 'No user id found'
 }
 
+gh auth status
+
 echo "Looking up sponsorship from $env:GITHUB_ACTOR ..."
 
 $query = gh api graphql --paginate -f owner='devlooped' -f query='

--- a/.netconfig
+++ b/.netconfig
@@ -88,8 +88,8 @@
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 872f3ab674ed375636eab6a34ae5d38426012ace
-	etag = 938aac551ff94e2882de1a679514b18c5a3248146d0d122ff75613e2cdf38e86
+	sha = 6edd918283051b5179f6255556d254654acc5b8c
+	etag = af2cf67157f42ab43a0082cbf876aa4cc46e167e6e6df6c05e9aaf36ffb23cc8
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
@@ -136,8 +136,8 @@
 	skip
 [file ".github/workflows/sponsors.ps1"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.ps1
-	sha = ffde0b030405ef9925309cf69467570c75b6edea
-	etag = 5e29155d35ab142150e900df391363e03e5a15a8be46e4adeeb4c6fd34013289
+	sha = 11f5c27cfdb304436ef0b7ee27ff333cda31ef65
+	etag = 57a303125f3367b68ad0700d89ff4ba57cb29b33b303903488c9c8638d0bf735
 	weak
 [file ".github/workflows/sponsors.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.yml
@@ -151,6 +151,6 @@
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = e977ded975b1a536e76d5577a15a8512570ad8c7
-	etag = a84e35210d22591f420ba49ffed469e23107fbccb685857a20188134026d91bd
+	sha = 094043587f7e7313a0a77dece1532fbcb1ce8555
+	etag = 15333d15756257ec2d7975ea3ba5a22d1e3fae98aab35d83d67a728628e90cea
 	weak

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -33,11 +33,6 @@
     <OutDir>$(OutputPath)</OutDir>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Define constant for TF like NET5, NET472, NETSTANDARD2, NETSTANDARD21 -->
-    <DefineConstants Condition="'$(TargetFramework)' != ''">$(DefineConstants);$(TargetFramework.ToUpperInvariant().TrimEnd('0').TrimEnd('.').Replace('.', ''))</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Consider the project out of date if any of these files changes -->
     <UpToDateCheck Include="@(PackageFile);@(None);@(Content);@(EmbeddedResource)" />


### PR DESCRIPTION
# devlooped/oss

- Rename changelog to sync [devlooped/oss@99c4bb7](https://github.com/devlooped/oss/commit/99c4bb740c516bd2953464f4fdbfa32bcbde6352)
- Remove DefineConstant since .NET5 SDK already provides them [devlooped/oss@6edd918](https://github.com/devlooped/oss/commit/6edd918283051b5179f6255556d254654acc5b8c)
- Update to public stable version of dotnet-file [devlooped/oss@3e86410](https://github.com/devlooped/oss/commit/3e864109790fc5c4a42edc106d9dd3ad4b204973)
- Use "Bump" in commit text, unifies with dependabot [devlooped/oss@0940435](https://github.com/devlooped/oss/commit/094043587f7e7313a0a77dece1532fbcb1ce8555)

# devlooped/.github

- :lock: Show gh auth status before running sponsors query [devlooped/.github@11f5c27](https://github.com/devlooped/.github/commit/11f5c27cfdb304436ef0b7ee27ff333cda31ef65)