### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2
+        with: 
+          submodules: recursive
+          fetch-depth: 0
+
       - name: ✓ ensure format
         run: |
           dotnet tool update -g dotnet-format --version 5.0.*

--- a/.netconfig
+++ b/.netconfig
@@ -43,8 +43,8 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = c2ad879554e326fbc80fa1bbdc2dbc22f53001e1
-	etag = 82a160cfc3042b7d277b13fe539b1f311a0afa264802d31330ac42b7beb37ae3
+	sha = 4bc9de2ce63f083c2805752a25c5997ebc102aeb
+	etag = 16edbc0d7121c2527f0e62d441bbb4ac2b1ffc7e25ccd4b3d0611c0c86716520
 	weak
 [file ".github_changelog_generator"]
 	url = https://github.com/devlooped/oss/blob/main/.github_changelog_generator
@@ -83,13 +83,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 16ac2f336b14d6b340b10fa162242a9742eb08fc
-	etag = 16762b7a7fbdc00c1912c469962131c912856115826db7628167517eea918324
+	sha = c9924b558ddeafb2cb547a7fcbc18aa7ae292ad1
+	etag = dc86d6818b98a7426c604039a07e134d61c8c598f1ceedb9e0e481fa0f93385d
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 6edd918283051b5179f6255556d254654acc5b8c
-	etag = af2cf67157f42ab43a0082cbf876aa4cc46e167e6e6df6c05e9aaf36ffb23cc8
+	sha = e7de4d0e790f9fe58f31308f95886884b6c5805f
+	etag = 9956aef0f3becce22fc1dc4e68dd218d5ba3c23de2b106c4ad006ad321cacc4a
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -63,18 +63,6 @@
     <!-- We typically don't want these files shown in the solution explorer -->
     <DefaultItemExcludes>$(DefaultItemExcludes);*.binlog;*.zip;*.rsp;*.items;**/TestResults/**/*.*</DefaultItemExcludes>
 
-    <!-- We use a single oss signing key for consumers that need strong-named assemblies -->
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)kzu.snk</AssemblyOriginatorKeyFile>
-    <!-- These properties make it easier to add internals visible to other projects, even when signing is involved.
-         For example, you can simply add: 
-          <InternalsVisibleTo Include="MyProject.UnitTests" />
-
-         and the key will be appended automatically.
-    -->
-    <PublicKey>002400000480000094000000060200000024000052534131000400000100010051155fd0ee280be78d81cc979423f1129ec5dd28edce9cd94fd679890639cad54c121ebdb606f8659659cd313d3b3db7fa41e2271158dd602bb0039a142717117fa1f63d93a2d288a1c2f920ec05c4858d344a45d48ebd31c1368ab783596b382b611d8c92f9c1b3d338296aa21b12f3bc9f34de87756100c172c52a24bad2db</PublicKey>
-    <PublicKeyToken>00352124762f2aa5</PublicKeyToken>
-    <SignAssembly>true</SignAssembly>
-
     <EnableSourceLink>true</EnableSourceLink>
     <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -90,6 +78,20 @@
     <NoWarn>NU5105;$(NoWarn)</NoWarn>
     <!-- Turn warnings into errors in CI or Release builds -->
     <WarningsAsErrors Condition="$(CI) or '$(Configuration)' == 'Release'">true</WarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">
+    <!-- We use a single oss signing key for consumers that need strong-named assemblies -->
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)kzu.snk</AssemblyOriginatorKeyFile>
+    <!-- These properties make it easier to add internals visible to other projects, even when signing is involved.
+         For example, you can simply add: 
+          <InternalsVisibleTo Include="MyProject.UnitTests" />
+
+         and the key will be appended automatically.
+    -->
+    <PublicKey>002400000480000094000000060200000024000052534131000400000100010051155fd0ee280be78d81cc979423f1129ec5dd28edce9cd94fd679890639cad54c121ebdb606f8659659cd313d3b3db7fa41e2271158dd602bb0039a142717117fa1f63d93a2d288a1c2f920ec05c4858d344a45d48ebd31c1368ab783596b382b611d8c92f9c1b3d338296aa21b12f3bc9f34de87756100c172c52a24bad2db</PublicKey>
+    <PublicKeyToken>00352124762f2aa5</PublicKeyToken>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <PropertyGroup Label="Version">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,10 @@
 <Project>
   <!-- To extend/change the defaults, create a Directory.targets alongside this file -->
 
+  <PropertyGroup Condition="'$(CI)' == 'true' and '$(Language)' == 'C#'">
+    <DefineConstants>CI;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(IsPackable)' == ''">
     <!-- The Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets unconditionally sets 
         PackageId=AssemblyName if no PackageId is provided, and then defaults IsPackable=true if 
@@ -36,9 +40,8 @@
   <ItemGroup>
     <!-- Consider the project out of date if any of these files changes -->
     <UpToDateCheck Include="@(PackageFile);@(None);@(Content);@(EmbeddedResource)" />
-    <!-- We'll typically use ThisAssembly.Strings instead of the built-in resource manager codegen
-         The built-in one can be restored with: <EmbeddedResource Update="@(EmbeddedResource)" Generator="ResXFileCodeGenerator" -->
-    <EmbeddedResource Update="@(EmbeddedResource)"  Generator="" />
+    <!-- We'll typically use ThisAssembly.Strings instead of the built-in resource manager codegen -->
+    <EmbeddedResource Update="@(EmbeddedResource)"  Generator="" Condition="'$(EnableRexCodeGenerator)' != 'true'" />
   </ItemGroup>
 
   <Target Name="IsPackable" Returns="@(IsPackable)">

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -13,6 +13,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)dotnet-config.snk</AssemblyOriginatorKeyFile>
     <PublicKey>002400000480000094000000060200000024000052534131000400000100010071207e0121c41cd25ecdf4dffe275b3a055b03e9f009f778b6bd0f0fe6643ac89ca3eeddf6d136496c4cd0defa1fcff361cc2c2c0d0a8f1b6ff92c15e661dee0acde682c4dcf78b7a30edd65737b54da568f4ec76b66827ce019093b9dedf80214b1a3d63d5289d542b3b218d7fe537d6da628d2718307190a5993d7fca0e3b1</PublicKey>
     <PublicKeyToken>41dc05ca892b85e5</PublicKeyToken>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# devlooped/oss

- Checkout submodules recursively for dotnet-format step https://github.com/devlooped/oss/commit/4bc9de2
- Allow projects to preserve default EmbeddedResource item behavior https://github.com/devlooped/oss/commit/f19d5dd
- Add a CI constant for use in code to detect CI-built code https://github.com/devlooped/oss/commit/e7de4d0
- Replace refs/tags too when considering version label https://github.com/devlooped/oss/commit/281b9b4
- Revert "Replace refs/tags too when considering version label" https://github.com/devlooped/oss/commit/7e15e3c
- Only set signing keyfile if it exists at default location https://github.com/devlooped/oss/commit/637662d
- Improve strong-naming properties defaults https://github.com/devlooped/oss/commit/c9924b5