### PR TITLE
≥ Add System.CommandLine support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: 🙏 build
-        run: dotnet build -p:BuildDocFx=true
+        run: dotnet build -p:BuildDocFx=true -p:DOCFX_SOURCE_BRANCH_NAME=main
 
       - name: 🚀 deploy 
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/Config.sln
+++ b/Config.sln
@@ -65,7 +65,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "partials", "partials", "{61
 		docs\template\partials\scripts.tmpl.partial = docs\template\partials\scripts.tmpl.partial
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Configuration", "src\Configuration\Configuration.csproj", "{27257308-72DF-4C4E-8B22-E7CD08984ABE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Configuration", "src\Configuration\Configuration.csproj", "{27257308-72DF-4C4E-8B22-E7CD08984ABE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLine", "src\CommandLine\CommandLine.csproj", "{545759D0-0144-4CEA-8AFF-73879FEFA918}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,6 +91,10 @@ Global
 		{27257308-72DF-4C4E-8B22-E7CD08984ABE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27257308-72DF-4C4E-8B22-E7CD08984ABE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27257308-72DF-4C4E-8B22-E7CD08984ABE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{545759D0-0144-4CEA-8AFF-73879FEFA918}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{545759D0-0144-4CEA-8AFF-73879FEFA918}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{545759D0-0144-4CEA-8AFF-73879FEFA918}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{545759D0-0144-4CEA-8AFF-73879FEFA918}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,8 +1,23 @@
-# dotnet-config API
+## API
 
-The main usage for .NET tool authors consuming the [DotNetConfig](https://nuget.org/packages/DotNetConfig) 
-API is to first build a configuration from a specific path (will assume current 
-directory if omitted):
+There are three main ways to access *.netconfig* values:
+
+* [Native API](#native-api) for direct access to .netconfig values
+* [Microsoft.Extensions.Configuration](#microsoftextensionsconfiguration) provider
+* [System.CommandLine](#systemcommandline) for CLI apps
+
+### Native API
+
+[![Version](https://img.shields.io/nuget/v/DotNetConfig.svg?color=royalblue)](https://www.nuget.org/packages/DotNetConfig)
+[![Downloads](https://img.shields.io/nuget/dt/DotNetConfig.svg?color=darkmagenta)](https://www.nuget.org/packages/DotNetConfig)
+
+```
+PM> Install-Package DotNetConfig
+```
+
+The main usage for .NET tool authors consuming the [DotNetConfig](https://www.nuget.org/packages/DotNetConfig) 
+API is to first build a configuration from a specific path (will assume current directory 
+if omitted):
 
 ```csharp
 var config = Config.Build();
@@ -52,7 +67,7 @@ if (!config.TryGetDateTime("mytool", "src/file.txt", "createdOn", out created))
 ```
 
 
-Since `.netconfig` supports multi-valued variables, you can retrieve them all 
+Since `.netconfig` supports multi-valued variables, you can retrieve all entries as 
 `ConfigEntry` and inspect or manipulate them granularly:
 
 ```csharp
@@ -63,6 +78,8 @@ foreach (ConfigEntry entry in config.GetAll("proxy", "url"))
         // entry came from Environment.SpecialFolder.System
     else if (entry.Level == ConfigLevel.Global)
         // entry came from Environment.SpecialFolder.UserProfile
+    else if (entry.Level == ConfigLevel.Local)
+        // entry came from .netconfig.user file in the current dir or an ancestor directory
     else
         // local entry from current dir .netconfig or an ancestor directory
 
@@ -79,5 +96,154 @@ configuration level to use for persisting the value, by passing a `ConfigLevel`:
 //[vs "alias"]
 //	comexp = run|community|exp
 
-config.AddString("vs", "alias", "comexp", "run|community|exp", ConfigLevel.Global);
+config = config.AddString("vs", "alias", "comexp", "run|community|exp", ConfigLevel.Global);
 ```
+
+> IMPORTANT: the Config API is immutable, so if you make changes, you should update your reference
+> to the newly updated Config, otherwise, subsequent changes would override prior ones.
+
+You can explore the entire API in the [docs site](https://dotnetconfig.org/api/).
+
+### Microsoft.Extensions.Configuration
+
+[![Version](https://img.shields.io/nuget/v/DotNetConfig.Configuration.svg?color=royalblue)](https://www.nuget.org/packages/DotNetConfig.Configuration)
+[![Downloads](https://img.shields.io/nuget/dt/DotNetConfig.Configuration.svg?color=darkmagenta)](https://www.nuget.org/packages/DotNetConfig.Configuration)
+
+```
+PM> Install-Package DotNetConfig.Configuration
+```
+
+Usage (in this example, also chaining other providers):
+
+```csharp
+var config = new ConfigurationBuilder()
+    .AddJsonFile(...)
+    .AddEnvironmentVariables()
+    .AddIniFile(...)
+    .AddDotNetConfig();
+```
+
+Given the following .netconfig: 
+
+```gitconfig
+[serve]
+	port = 8080
+
+[security "admin"]
+    timeout = 60
+```
+
+You can read both values with:
+
+```csharp
+string port = config["serve:port"];  // == "8080";
+string timeout = config["security:admin:timeout"];  // == "60";
+```
+
+### System.CommandLine
+
+[![Version](https://img.shields.io/nuget/v/DotNetConfig.CommandLine.svg?color=royalblue)](https://www.nuget.org/packages/DotNetConfig.CommandLine)
+[![Downloads](https://img.shields.io/nuget/dt/DotNetConfig.CommandLine.svg?color=darkmagenta)](https://www.nuget.org/packages/DotNetConfig.CommandLine)
+
+Given the explicit goal of making **.netconfig** a first-class citizen among dotnet (global) tools, it offers 
+excelent and seamless integration with [System.CommandLine](https://www.nuget.org/packages/System.CommandLine).
+
+Let's asume you create a CLI app named `package` which manages your local cache of packages (i.e. NuGet). 
+You might have a couple commands, like `download` and `prune`, like so:
+
+```csharp
+var root = new RootCommand
+{
+  new Command("download")
+  {
+    new Argument<string>("id")
+  },
+  new Command("prune")
+  {
+    new Argument<string>("id"),
+    new Option<int>("days")
+  },
+}.WithConfigurableDefaults("package");
+```
+
+The added `WithConfigurableDefaults` invocation means that now all arguments and options can have 
+their default values specified in config, such as:
+
+```gitconfig
+[package]
+  id = DotNetConfig
+
+[package "prune"]
+  days = 30
+```
+
+Note how the `id` can be specified at the top level too. The integration will automatically promote 
+configurable values to ancestor sections as long as they have compatible types (both `id` in `download` 
+and `prune` commands are defined as `string`).
+
+Running `package -?` from the command line will now pull the rendered default values from config, so 
+you can see what will actually be used if the command is run with no values:
+
+```
+Usage:
+  package [options] [command]
+
+Options:
+  --version       Show version information
+  -?, -h, --help  Show help and usage information
+
+Commands:
+  download <id>  [default: DotNetConfig]
+  prune <id>     [default: DotNetConfig]
+```
+
+And `package prune -?` would show:
+
+```
+Usage:
+  package [options] prune [<id>]
+
+Arguments:
+  <id>  [default: DotNetConfig]
+
+Options:
+  --days <days>   [default: 30]
+  -?, -h, --help  Show help and usage information
+```
+
+Since **.netconfig** supports multi-valued variables, it's great for populating default 
+values for arguments or options that can be specified more than once. By making this 
+simple change to the argument above:
+
+```csharp
+    new Argument<string[]>("id")
+```
+
+We can now support a configuration like the following:
+
+```gitconfig
+[package]
+  id = DotNetConfig
+  id = Moq
+  id = ThisAssembly
+```
+
+And running the command with no `id` argument will now cause the handler to receive all three. You 
+can also verify that this is the case via `download -?`, for example:
+
+```
+Usage:
+  package [options] download [<id>...]
+
+Arguments:
+  <id>  [default: DotNetConfig|Moq|ThisAssembly]
+
+Options:
+  -?, -h, --help  Show help and usage information
+```
+
+All the types supported by System.CommandLine for multiple artity arguments and options are 
+automatically populated: arrays, `IEnumerable<T>`, `ICollection<T>`, `IList<T>` and `List<T>`. 
+
+For numbers, the argument/option can be either `long` or `int`. Keep in mind that since numbers in 
+**.netconfig** are always `long`, truncation may occur in the latter case.

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -10,6 +10,10 @@
         {
           "files": [ "*.cs" ],
           "src": "../src/Configuration"
+        },
+        {
+          "files": [ "*.cs" ],
+          "src": "../src/CommandLine"
         }
       ],
       "dest": "docs/api"

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -1,0 +1,49 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>DotNetConfig.CommandLine</PackageId>
+    <Description>Extensions to System.CommandLine to automatically read default values from .netconfig files.
+
+Usage:
+   var root = new RootCommand
+   {
+     // child commands, arguments, options
+   }.WithConfigurableDefaults();
+
+
+The following heuristics are applied when providing default values:
+
+* Only arguments/options without a default value are processed.
+* Section matches root command name, subsection (dot-separated) for each additional nested 
+  command level (i.e. `[mytool "mycommand.myverb"]`).
+* Compatible arguments/options (same name/type) can be placed in ancestor section/subsection to affect 
+  default value of entire subtree.
+* All the types supported by System.CommandLine for multiple artity arguments and options are 
+  automatically populated: arrays, `IEnumerable{T}`, `ICollection{T}`, `IList{T}` and `List{T}`: 
+  .netconfig can provide multi-valued variables for those.
+* Numbers can be either `int` or `long`.
+
+</Description>
+
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>DotNetConfig.CommandLine</AssemblyName>
+    <RootNamespace>DotNetConfig</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Deterministic>true</Deterministic>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Config\Range.cs" Link="Range.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Config\Config.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CommandLine/CommandLineExtensions.cs
+++ b/src/CommandLine/CommandLineExtensions.cs
@@ -1,0 +1,390 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using DotNetConfig;
+
+namespace System.CommandLine
+{
+    /// <summary>
+    /// Extension methods to automatically read default values for arguments and 
+    /// options from .netconfig.
+    /// </summary>
+    /// <remarks>
+    /// After invoking <see cref="WithConfigurableDefaults"/> on a command, all its 
+    /// arguments and options in the entire command tree are processed according to 
+    /// these heuristics:
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// Only arguments/options without a default value are processed
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// Section matches root command name, subsection (dot - separated) for each additional nested
+    /// command level(i.e. `[mytool "mycommand.myverb"]`)
+    /// </description>
+    /// </item>
+    /// <description>
+    /// Compatible arguments/options(same name/type) can be placed in ancestor section/subsection to affect 
+    /// default value of entire subtree
+    /// </description>
+    /// <item>
+    /// <description>
+    /// All the types supported by System.CommandLine for multiple artity arguments and options are
+    /// automatically populated: arrays, `IEnumerable{T}`, `ICollection{T}`, `IList{T}` and `List{T}`: 
+    /// .netconfig can provide multi-valued variables for those
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// Numbers can be either `int` or `long`.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// </remarks>
+    public static class CommandLineExtensions
+    {
+        static readonly HashSet<Type> configurableTypes = new HashSet<Type>(new[]
+        {
+            typeof(string),
+            typeof(long),
+            typeof(long?),
+            typeof(int),
+            typeof(int?),
+            typeof(bool),
+            typeof(bool?),
+            typeof(DateTime),
+            typeof(DateTime?),
+        });
+
+        /// <summary>
+        /// Register default value factories for all arguments and options in the command tree 
+        /// which don't have a default value already.
+        /// </summary>
+        /// <typeparam name="T">Type of command, inferred from usage.</typeparam>
+        /// <param name="command">The command to set default values for.</param>
+        /// <param name="section">Optional root section for this command arguments and its tree. If not provided, the <paramref name="command"/>'s <c>Name</c>
+        /// property will be used. For a <see cref="RootCommand"/>, this is the app's assembly name.</param>
+        /// <param name="configuration">Optional pre-built configuration. If not provided, <see cref="Config.Build(string?)"/> will 
+        /// be used to build a default configuration.</param>
+        /// <returns>The command where defaults have been applied.</returns>
+        public static T WithConfigurableDefaults<T>(this T command, string? section = default, Config? configuration = default) where T : Command
+        {
+            configuration ??= Config.Build();
+            section ??= command.Name;
+
+            var arguments = new HashSet<IArgument>();
+            CollectArguments(command, arguments);
+
+            var sections = new ConcurrentDictionary<(string? subsection, string variable), HashSet<IArgument>>();
+            PopulateSections(command, sections, arguments, null);
+
+            // Clear sections with multiple variables but with incompatible types
+            foreach (var entry in sections.Where(x => x.Value.GroupBy(arg => arg.ValueType).Skip(1).Any()).ToArray())
+                sections.TryRemove(entry.Key, out _);
+
+            // Remaining sections are all the final arguments for defaulting.
+            var factories = new ConcurrentDictionary<IArgument, DefaultValueFactory>();
+            foreach (var sharedSection in sections)
+            {
+                foreach (var argument in sharedSection.Value)
+                {
+                    factories.GetOrAdd(argument, arg => new DefaultValueFactory(arg, configuration, section))
+                        .AddSubsection(sharedSection.Key.subsection);
+                }
+            }
+
+            foreach (var factory in factories.Values)
+                factory.SetDefaultValue();
+
+            return command;
+        }
+
+        static void PopulateSections(Command command,
+            ConcurrentDictionary<(string? subsection, string variable), HashSet<IArgument>> sections,
+            HashSet<IArgument> arguments,
+            string? subsection = null)
+        {
+            void Add(IEnumerable<IArgument> args)
+            {
+                foreach (var arg in args)
+                {
+                    if (subsection != null)
+                    {
+                        var parts = subsection.Split('.');
+                        for (var i = 1; i <= parts.Length; i++)
+                            sections.GetOrAdd((string.Join(".", parts[0..i]), arg.Name), _ => new()).Add(arg);
+
+                        sections.GetOrAdd((null, arg.Name), _ => new()).Add(arg);
+                    }
+                    else
+                    {
+                        sections.GetOrAdd((subsection, arg.Name), _ => new()).Add(arg);
+                    }
+                }
+            }
+
+            Add(command.Arguments.Where(arg => arguments.Contains(arg)));
+            Add(command.Options.OfType<IOption>().Select(x => x.Argument).Where(x => arguments.Contains(x)));
+
+            foreach (var child in command.OfType<Command>())
+                PopulateSections(child, sections, arguments, subsection == null ? child.Name : subsection + "." + child.Name);
+        }
+
+        static void CollectArguments(
+            Command command,
+            HashSet<IArgument> arguments)
+        {
+            foreach (var symbol in command)
+            {
+                if (symbol is Command nested)
+                {
+                    CollectArguments(nested, arguments);
+                }
+                else
+                {
+                    var arg = symbol as IArgument ?? (symbol as IOption)?.Argument;
+                    if (arg == null || arg.HasDefaultValue)
+                        continue;
+
+                    // This check must go first since typeof(string) is also enumerable.
+                    if (configurableTypes.Contains(arg.ValueType))
+                    {
+                        arguments.Add(arg);
+                    }
+                    else if (arg.Arity.MaximumNumberOfValues > 1)
+                    {
+                        if (arg.ValueType.IsArray && configurableTypes.Contains(arg.ValueType.GetElementType()))
+                            arguments.Add(arg);
+                        else if (arg.ValueType.IsGenericType &&
+                            IsCompatibleGenericType(arg.ValueType) &&
+                            configurableTypes.Contains(arg.ValueType.GetGenericArguments()[0]))
+                            arguments.Add(arg);
+                    }
+                }
+
+                // These are the supported conversions in System.CommandLine, see 
+                // https://github.com/dotnet/command-line-api/blob/main/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs#L566-L587
+                static bool IsCompatibleGenericType(Type type) =>
+                    type.GetGenericTypeDefinition() == typeof(IEnumerable<>) ||
+                    type.GetGenericTypeDefinition() == typeof(IList<>) ||
+                    type.GetGenericTypeDefinition() == typeof(ICollection<>) ||
+                    type.GetGenericTypeDefinition() == typeof(List<>);
+            }
+        }
+
+        class DefaultValueFactory
+        {
+            readonly Argument argument;
+            readonly Config config;
+            readonly string section;
+            readonly HashSet<string?> subsections = new();
+            string?[] orderedSubsections = Array.Empty<string?>();
+
+            public DefaultValueFactory(IArgument argument, Config config, string section)
+                => (this.argument, this.config, this.section)
+                // NOTE: this is the only downcast to Argument, since SetDefaultValueFactory is not 
+                // present at the interface level.
+                = (argument as Argument ?? throw new ArgumentException(), config, section);
+
+            public void AddSubsection(string? subsection) => subsections.Add(subsection);
+
+            public void SetDefaultValue()
+            {
+                orderedSubsections = subsections.OrderByDescending(x => x?.Length ?? 0).ToArray();
+
+                if (argument.Arity.MaximumNumberOfValues > 1)
+                {
+                    // We have already validated that it's either an array or IEnumerable<T>
+                    var elementType = argument.ArgumentType.IsArray ?
+                        argument.ArgumentType.GetElementType() :
+                        argument.ArgumentType.GetGenericArguments()[0];
+
+                    switch (elementType)
+                    {
+                        case Type type when type.IsAssignableFrom(typeof(string)):
+                            SetDefaultStrings();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(long)):
+                            SetDefaultNumbers();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(int)):
+                            SetDefaultIntegers();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(bool)):
+                            SetDefaultBooleans();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(DateTime)):
+                            SetDefaultDateTimes();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                {
+                    switch (argument.ArgumentType)
+                    {
+                        case Type type when type.IsAssignableFrom(typeof(string)):
+                            SetDefaultString();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(long)) || type.IsAssignableFrom(typeof(int)):
+                            SetDefaultNumber();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(bool)):
+                            SetDefaultBoolean();
+                            break;
+                        case Type type when type.IsAssignableFrom(typeof(DateTime)):
+                            SetDefaultDateTime();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            void SetDefaultStrings()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    var values = new List<string>();
+                    foreach (var subsection in orderedSubsections)
+                        values.AddRange(config.GetAll(section, subsection, argument.Name).Select(x => x.GetString()));
+
+                    if (argument.ArgumentType.IsArray)
+                        return values.ToArray();
+
+                    return values;
+                });
+            }
+
+            void SetDefaultNumbers()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    var values = new List<long>();
+                    foreach (var subsection in orderedSubsections)
+                        values.AddRange(config.GetAll(section, subsection, argument.Name).Select(x => x.GetNumber()));
+
+                    if (argument.ArgumentType.IsArray)
+                        return values.ToArray();
+
+                    return values;
+                });
+            }
+
+            void SetDefaultIntegers()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    var values = new List<int>();
+                    foreach (var subsection in orderedSubsections)
+                        values.AddRange(config.GetAll(section, subsection, argument.Name).Select(x => (int)x.GetNumber()));
+
+                    if (argument.ArgumentType.IsArray)
+                        return values.ToArray();
+
+                    return values;
+                });
+            }
+
+            void SetDefaultBooleans()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    var values = new List<bool>();
+                    foreach (var subsection in orderedSubsections)
+                        values.AddRange(config.GetAll(section, subsection, argument.Name).Select(x => x.GetBoolean()));
+
+                    if (argument.ArgumentType.IsArray)
+                        return values.ToArray();
+
+                    return values;
+                });
+            }
+
+            void SetDefaultDateTimes()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    var values = new List<DateTime>();
+                    foreach (var subsection in orderedSubsections)
+                        values.AddRange(config.GetAll(section, subsection, argument.Name).Select(x => x.GetDateTime()));
+
+                    if (argument.ArgumentType.IsArray)
+                        return values.ToArray();
+
+                    return values;
+                });
+            }
+
+            void SetDefaultString()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    foreach (var subsection in orderedSubsections)
+                    {
+                        if (config.TryGetString(section, subsection, argument.Name, out var value))
+                            return value;
+                    }
+                    return default;
+                });
+            }
+
+            void SetDefaultNumber()
+            {
+                if (argument.ArgumentType == typeof(int))
+                {
+                    argument.SetDefaultValueFactory(() =>
+                    {
+                        foreach (var subsection in orderedSubsections)
+                        {
+                            if (config.TryGetNumber(section, subsection, argument.Name, out var value))
+                                return (int)value;
+                        }
+                        return default;
+                    });
+                }
+                else
+                {
+                    argument.SetDefaultValueFactory(() =>
+                    {
+                        foreach (var subsection in orderedSubsections)
+                        {
+                            if (config.TryGetNumber(section, subsection, argument.Name, out var value))
+                                return value;
+                        }
+                        return default;
+                    });
+                }
+            }
+
+            void SetDefaultBoolean()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    foreach (var subsection in orderedSubsections)
+                    {
+                        if (config.TryGetBoolean(section, subsection, argument.Name, out var value))
+                            return value;
+                    }
+                    return default;
+                });
+            }
+
+            void SetDefaultDateTime()
+            {
+                argument.SetDefaultValueFactory(() =>
+                {
+                    foreach (var subsection in orderedSubsections)
+                    {
+                        if (config.TryGetDateTime(section, subsection, argument.Name, out var value))
+                            return value;
+                    }
+                    return default;
+                });
+            }
+        }
+    }
+}

--- a/src/Config.Tests/CommandLineTests.cs
+++ b/src/Config.Tests/CommandLineTests.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
+using System.IO;
+using System.Linq;
+using Medallion.Collections;
+using Xunit;
+
+namespace DotNetConfig
+{
+    public class CommandLineTests
+    {
+        internal static string[] SeverityLevels => new[] { "info", "warn", "error" };
+
+        [Fact]
+        public void when_argument_no_default_then_sets_default()
+        {
+            var command = new Command("foo")
+            {
+                new Argument<string>("string"),
+                new Argument<long>("long"),
+                new Argument<int>("int"),
+                new Argument<DateTime>("date"),
+                new Argument<bool>("bool"),
+                new Argument<string?>("string2"),
+                new Argument<long?>("long2"),
+                new Argument<int?>("int2"),
+                new Argument<DateTime?>("date2"),
+                new Argument<bool?>("bool2"),
+            }.WithConfigurableDefaults();
+
+            Assert.True(command.Arguments.All(x => x.HasDefaultValue));
+        }
+
+        [Fact]
+        public void given_command_tree_sets_all_default()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .SetString("foo", "name", "foo")
+                .SetString("foo", "bar", "name", "bar")
+                .SetBoolean("foo", "baz", "force", true)
+                .SetString("foo", "baz.update", "name", "baz");
+
+            var command = new Command("foo")
+            {
+                new Command("bar")
+                {
+                    new Argument<string?>("name"),
+                },
+                new Command("baz")
+                {
+                    new Command("update")
+                    {
+                        new Argument<string?>("name"),
+                    },
+                    new Command("install")
+                    {
+                        new Argument<string?>("name"),
+                    },
+                    new Command("uninstall")
+                    {
+                        new Argument<string?>("name"),
+                        new Option<bool?>("force"),
+                    },
+                },
+            }.WithConfigurableDefaults(configuration: config);
+
+            Assert.True(Traverse
+                .BreadthFirst(command, c => c.Children.OfType<Command>())
+                .SelectMany(x => x.Arguments).All(x => x.HasDefaultValue));
+
+            // Gets from the command-specific section
+            Assert.Equal("bar", command.Children.OfType<Command>().First().Arguments[0].GetDefaultValue());
+            Assert.Equal("baz", Traverse
+                .DepthFirst(command, c => c.Children.OfType<Command>())
+                .First(c => c.Name == "update")
+                .Arguments[0].GetDefaultValue());
+
+            // Uses default from lifted top-level section for shared "name" argument
+            Assert.Equal("foo", Traverse
+                .DepthFirst(command, c => c.Children.OfType<Command>())
+                .First(c => c.Name == "install")
+                .Arguments[0].GetDefaultValue());
+
+            // Non-shared but still lifted since no conflicts
+            Assert.True(Traverse
+                .DepthFirst(command, c => c.Children.OfType<Command>())
+                .First(c => c.Name == "uninstall")
+                .Options.OfType<IOption>().First().Argument.GetDefaultValue() as bool?);
+        }
+
+        [Fact]
+        public void given_string_array_sets_all_values()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .AddString("cli", "include", "foo")
+                .AddString("cli", "include", "bar")
+                .AddString("cli", "include", "baz");
+
+            var command = new RootCommand()
+            {
+                new Argument<string[]>("include"),
+            }.WithConfigurableDefaults("cli", configuration: config);
+
+            Assert.Equal(new[] { "foo", "bar", "baz" }, (string[]?)command.Arguments[0].GetDefaultValue());
+
+            command.Handler = CommandHandler.Create<string[]>(include =>
+                Assert.Equal(new[] { "foo", "bar", "baz" }, include));
+
+            new CommandLineBuilder(command).Build().Invoke(new string[] { });
+        }
+
+        [Fact]
+        public void given_string_list_sets_all_values()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .AddString("cli", "include", "foo")
+                .AddString("cli", "include", "bar")
+                .AddString("cli", "include", "baz");
+
+            var command = new RootCommand()
+            {
+                new Argument<List<string>>("include"),
+            }.WithConfigurableDefaults("cli", configuration: config);
+
+            Assert.Equal(new[] { "foo", "bar", "baz" }, (IEnumerable<string>?)command.Arguments[0].GetDefaultValue());
+
+            command.Handler = CommandHandler.Create<List<string>>(include =>
+                Assert.Equal(new[] { "foo", "bar", "baz" }, include));
+
+            new CommandLineBuilder(command).Build().Invoke(new string[] { });
+        }
+
+        [Fact]
+        public void given_string_ilist_sets_all_values()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .AddString("cli", "include", "foo")
+                .AddString("cli", "include", "bar")
+                .AddString("cli", "include", "baz");
+
+            var command = new RootCommand()
+            {
+                new Argument<IList<string>>("include"),
+            }.WithConfigurableDefaults("cli", configuration: config);
+
+            Assert.Equal(new[] { "foo", "bar", "baz" }, (IEnumerable<string>?)command.Arguments[0].GetDefaultValue());
+
+            command.Handler = CommandHandler.Create<IList<string>>(include =>
+                Assert.Equal(new[] { "foo", "bar", "baz" }, include));
+
+            new CommandLineBuilder(command).Build().Invoke(new string[] { });
+        }
+
+        [Fact]
+        public void given_string_icollection_sets_all_values()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .AddString("cli", "include", "foo")
+                .AddString("cli", "include", "bar")
+                .AddString("cli", "include", "baz");
+
+            var command = new RootCommand()
+            {
+                new Argument<ICollection<string>>("include"),
+            }.WithConfigurableDefaults("cli", configuration: config);
+
+            Assert.Equal(new[] { "foo", "bar", "baz" }, (IEnumerable<string>?)command.Arguments[0].GetDefaultValue());
+
+            command.Handler = CommandHandler.Create<ICollection<string>>(include =>
+                Assert.Equal(new[] { "foo", "bar", "baz" }, include));
+
+            new CommandLineBuilder(command).Build().Invoke(new string[] { });
+        }
+
+        [Fact]
+        public void given_int_array_sets_all_values()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .AddNumber("cli", "include", 25)
+                .AddNumber("cli", "include", 50)
+                .AddNumber("cli", "include", 100);
+
+            var command = new RootCommand()
+            {
+                new Argument<int[]>("include"),
+            }.WithConfigurableDefaults("cli", configuration: config);
+
+            command.Handler = CommandHandler.Create<int[]>(include =>
+                Assert.Equal(new[] { 25, 50, 100 }, include));
+
+            new CommandLineBuilder(command).Build().Invoke(new string[] { });
+        }
+
+        [Fact]
+        public void given_long_array_sets_all_values()
+        {
+            var config = Config.Build(Path.GetTempFileName())
+                .AddNumber("cli", "include", 25)
+                .AddNumber("cli", "include", 50)
+                .AddNumber("cli", "include", 100);
+
+            var command = new RootCommand()
+            {
+                new Argument<long[]>("include"),
+            }.WithConfigurableDefaults("cli", configuration: config);
+
+            command.Handler = CommandHandler.Create<long[]>(include =>
+                Assert.Equal(new long[] { 25, 50, 100 }, include));
+
+            new CommandLineBuilder(command).Build().Invoke(new string[] { });
+        }
+
+        [Fact]
+        public void SetDefaults()
+        {
+            // Sync changes to option and argument names with the FormatCommant.Handler above.
+            var rootCommand = new RootCommand
+            {
+                new Argument<string?>("workspace")
+                {
+                    Arity = ArgumentArity.ZeroOrOne,
+                }.LegalFilePathsOnly(),
+                new Option(new[] { "--no-restore" }),
+                new Option(new[] { "--folder", "-f" }),
+                new Option(new[] { "--fix-whitespace", "-w" }),
+                new Option<string?>(new[] { "--fix-style", "-s" }) { Name = "severity" }.FromAmong(SeverityLevels),
+                new Option<string?>(new[] { "--fix-analyzers", "-a" }).FromAmong(SeverityLevels),
+                //{
+                    //Argument = new Argument<string?>("severity") { Arity = ArgumentArity.ZeroOrOne }.FromAmong(SeverityLevels)
+                //},
+                new Option<string[]>(new[] { "--diagnostics" }, () => Array.Empty<string>())
+                {
+                    //Argument = new Argument<string[]>(() => Array.Empty<string>())
+                },
+                new Option(new[] { "--include" })
+                {
+                    //Argument = new Argument<string[]>(() => Array.Empty<string>())
+                },
+                new Option(new[] { "--exclude" })
+                {
+                    //Argument = new Argument<string[]>(() => Array.Empty<string>())
+                },
+                new Option(new[] { "--check" }),
+                new Option(new[] { "--report" })
+                {
+                    //Argument = new Argument<string?>(() => null) { Name = "report-path" }.LegalFilePathsOnly()
+                },
+                new Option(new[] { "--verbosity", "-v" })
+                {
+                    //Argument = new Argument<string?>() { Arity = ArgumentArity.ExactlyOne }.FromAmong(VerbosityLevels)
+                },
+                new Option(new[] { "--include-generated" })
+                {
+                    IsHidden = true
+                },
+                new Option(new[] { "--binarylog" })
+                {
+                    //Argument = new Argument<string?>(() => null) { Name = "binary-log-path", Arity = ArgumentArity.ZeroOrOne }.LegalFilePathsOnly()
+                },
+            };
+        }
+    }
+}

--- a/src/Config.Tests/Config.Tests.csproj
+++ b/src/Config.Tests/Config.Tests.csproj
@@ -20,17 +20,22 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-    <ProjectProperty Include="OutputPath"/>
-    <ProjectProperty Include="MSBuildProjectDirectory"/>
+    <ProjectProperty Include="OutputPath" />
+    <ProjectProperty Include="MSBuildProjectDirectory" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="netfx-System.Collections.Generic.IEnumerable.Traverse" Version="1.1.0" />
+    <PackageReference Include="StrongNamer" Version="0.2.5" />
+    <PackageReference Include="Traverse" Version="1.0.1" />
     <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="ThisAssembly" Version="1.0.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.14" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21227.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,8 +43,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Configuration\Configuration.csproj" />
     <ProjectReference Include="..\Config\Config.csproj" />
+    <ProjectReference Include="..\Configuration\Configuration.csproj" />
+    <ProjectReference Include="..\CommandLine\CommandLine.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Config.Tests/ConfigurationTests.cs
+++ b/src/Config.Tests/ConfigurationTests.cs
@@ -20,7 +20,7 @@ namespace DotNetConfig
         }
 
         [FlakyFact]
-        public void LoadHierarchicalValues()
+        public void can_load_hierarchical_values()
         {
             var config = new ConfigurationBuilder().AddDotNetConfig().Build();
             Assert.Equal("on", config["core:parent"]);
@@ -30,7 +30,7 @@ namespace DotNetConfig
         }
 
         [FlakyFact]
-        public void SaveValues()
+        public void can_save_values()
         {
             var config = new ConfigurationBuilder().AddDotNetConfig().Build();
             config["foo:enabled"] = "true";

--- a/src/Config.Tool/Config.Tool.csproj
+++ b/src/Config.Tool/Config.Tool.csproj
@@ -1,7 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>A global tool for managing hierarchical configurations for dotnet tools, using git config format.</Description>
+    <Description>A global tool for managing hierarchical configurations for dotnet tools, using git config format.
+    
+Usage: dotnet config [options]
+
+Location (uses all locations by default)
+      --local                use .netconfig.user file
+      --global               use global config file
+      --system               use system config file
+      --path[=VALUE]         use given config file or directory
+
+Action
+      --get                  get value: name [value-regex]
+      --get-all              get all values: key [value-regex]
+      --get-regexp           get values for regexp: name-regex [value-regex]
+      --set                  set value: name value [value-regex]
+      --set-all              set all matches: name value [value-regex]
+      --add                  add a new variable: name value
+      --unset                remove a variable: name [value-regex]
+      --unset-all            remove all matches: name [value-regex]
+      --remove-section       remove a section: name
+      --rename-section       rename section: old-name new-name
+  -l, --list                 list all
+  -e, --edit                 edit the config file in an editor
+
+Other
+      --default[=VALUE]      with --get, use default value when missing entry
+      --name-only            show variable names only
+      --type[=VALUE]         value is given this type, can be 'boolean', '
+                               datetime' or 'number'
+  -?, -h, --help             Display this help
+</Description>
 
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
@@ -24,7 +54,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
-    <PackageReference Include="ThisAssembly" Version="1.0.7" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly" Version="1.0.8" PrivateAssets="all" />
     <PackageReference Include="StrongNamer" Version="0.2.5" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Config/Config.csproj
+++ b/src/Config/Config.csproj
@@ -1,7 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>APIs for handling dotnet-config compatible settings for any dotnet tool.</Description>
+    <Description>APIs for handling dotnet-config compatible settings for any dotnet tool.
+
+Usage: 
+  var config = Config.Build();
+  var value = config.GetString("section", "subsection", "variable");
+
+  // Setting values, Config is immutable, so chain calls and update var
+  config = config
+    .SetString("section", "subsection", "variable", value)
+    .SetBoolean("section", "subsection", "enabled", true);
+</Description>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>DotNetConfig</AssemblyName>
@@ -24,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="ThisAssembly" Version="1.0.7" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly" Version="1.0.8" PrivateAssets="all" />
     <PackageReference Include="docfx.console" Version="2.57.2" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Configuration/Configuration.csproj
+++ b/src/Configuration/Configuration.csproj
@@ -2,7 +2,14 @@
 
   <PropertyGroup>
     <PackageId>DotNetConfig.Configuration</PackageId>
-    <Description>DotNetConfig configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
+    <Description>DotNetConfig configuration provider implementation for Microsoft.Extensions.Configuration.
+    
+Usage:
+    var config = new ConfigurationBuilder().AddDotNetConfig().Build();
+    var value = config["section:subsection:variable"]);
+
+Note: section is required and subsection is optional, just like in dotnet-config.
+    </Description>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>DotNetConfig.Configuration</AssemblyName>

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <RestoreSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json;$(RestoreSources)</RestoreSources>
+
     <!-- Because it's sooo much better than GeneratePackageOnBuild! -->
     <PackOnBuild Condition="$(CI) or '$(BuildingInsideVisualStudio)' != 'true'">true</PackOnBuild>
     <GeneratePackageOnBuild>$(PackOnBuild)</GeneratePackageOnBuild>
@@ -14,6 +16,8 @@
     <PublicKey>002400000480000094000000060200000024000052534131000400000100010071207e0121c41cd25ecdf4dffe275b3a055b03e9f009f778b6bd0f0fe6643ac89ca3eeddf6d136496c4cd0defa1fcff361cc2c2c0d0a8f1b6ff92c15e661dee0acde682c4dcf78b7a30edd65737b54da568f4ec76b66827ce019093b9dedf80214b1a3d63d5289d542b3b218d7fe537d6da628d2718307190a5993d7fca0e3b1</PublicKey>
     <PublicKeyToken>41dc05ca892b85e5</PublicKeyToken>
     <SignAssembly>true</SignAssembly>
+
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
A single extension method `WithConfigurableDefaults` on a command will apply default value retrieval from .netconfig for an entire command tree, with the following rules:

* Only arguments/options without a default value are processed.
* Section matches root command name, subsection (dot-separated) for each additional nested
  command level (i.e. `[mytool "mycommand.myverb"]`).
* Compatible arguments/options (same name/type) can be placed in ancestor section/subsection to affect
  default value of entire subtree.
* All the types supported by System.CommandLine for multiple artity arguments and options are
  automatically populated: arrays, `IEnumerable{T}`, `ICollection{T}`, `IList{T}` and `List{T}`:
  .netconfig can provide multi-valued variables for those.
* Numbers can be either `int` or `long`.

Fixes #18