### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,34 @@ updates:
   directory: /
   schedule:
     interval: daily
+  groups:
+    Azure:
+      patterns:
+        - "Azure*"
+        - "Microsoft.Azure*"
+    Identity:
+      patterns:
+        - "System.IdentityModel*"
+        - "Microsoft.IdentityModel*"
+    System:
+      patterns:
+        - "System*"
+      exclude-patterns:
+        - "System.IdentityModel*"
+    Extensions:
+      patterns:
+        - "Microsoft.Extensions*"
+    Web:
+      patterns:
+        - "Microsoft.AspNetCore*"
+    Tests:
+      patterns:
+        - "Microsoft.NET.Tests*"
+        - "xunit*"
+        - "coverlet*"
+    ThisAssembly:
+      patterns:
+        - "ThisAssembly*"
+    ProtoBuf:
+      patterns:
+        - "protobuf-*"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TestResults
 .vs
 .vscode
 .idea
+local.settings.json
 
 *.suo
 *.sdf
@@ -31,5 +32,6 @@ node_modules
 _site
 .jekyll-metadata
 .jekyll-cache
+.sass-cache
 Gemfile.lock
 package-lock.json

--- a/.netconfig
+++ b/.netconfig
@@ -22,8 +22,8 @@
 	weak
 [file ".github/dependabot.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/dependabot.yml
-	sha = 4f070a477b4162a280f02722ae666376ae4fcc71
-	etag = 35f2134fff3b0235ff8dac8618a76198c8ef533ad2f29628bbb435cd1134d638
+	sha = 35ca3f3405452465058d89005f8a88a65847c377
+	etag = f8080f8f04d87529e90d9a66751d304a7141196fb9734aa2d110784e52e66898
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
@@ -32,8 +32,8 @@
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = b87a8a795a4c2b6830602225c066c11108552a99
-	etag = 96e0860052044780f1fc9e3bdfbee09d82d5dddb8b1217d67460fc7330a64dd8
+	sha = 4bd702593c10df189cd4a0f6e6fb72e55de02198
+	etag = f11dcc8c057bd2f526aa9c7090c9568d1656fafaaedc6719da42a00283018ffa
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -52,13 +52,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 6ae80a175a8f926ac5d9ffb0f6afd55d85cc9320
-	etag = 69d4b16c14d5047b3ed812dbf556b0b8d77deb86f73af04b9bd3640220056fa8
+	sha = 1bf1eacc7ac3920d52c8e7045bfa34abc7c05302
+	etag = e9fd8ef4740d5559fa495580b04ec3437b99edbfb8452813907337f9374c1282
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 1514d15399a7d545ad92a0e9d57dc8295fdd6af8
-	etag = 428f80b0786ff17b836c7a5b0640948724855d17933e958642b22849ac00dadb
+	sha = 1bf1eacc7ac3920d52c8e7045bfa34abc7c05302
+	etag = 7cb1421f00d9f6f4c00f0ca98e485dcadb927cfa6b3f0b5d4fb212525d2ce9c0
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,10 +26,10 @@
 
     <!-- Pick src-level readme+icon automatically -->
     <PackageIcon Condition="Exists('$(MSBuildThisFileDirectory)icon.png')">icon.png</PackageIcon>
-    <PackageReadmeFile Condition="Exists('$(MSBuildThisFileDirectory)readme.md')">readme.md</PackageReadmeFile>
+    <PackageReadmeFile Condition="'$(PackReadme)' != 'false' and Exists('$(MSBuildThisFileDirectory)readme.md')">readme.md</PackageReadmeFile>
     <!-- Pick project-level readme+icon overrides automatically -->
     <PackageIcon Condition="Exists('$(MSBuildProjectDirectory)\icon.png')">icon.png</PackageIcon>
-    <PackageReadmeFile Condition="Exists('$(MSBuildProjectDirectory)\readme.md')">readme.md</PackageReadmeFile>
+    <PackageReadmeFile Condition="'$(PackReadme)' != 'false' and Exists('$(MSBuildProjectDirectory)\readme.md')">readme.md</PackageReadmeFile>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateRepositoryUrlAttribute>true</GenerateRepositoryUrlAttribute>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -35,16 +35,16 @@
 
     <None Update="@(None -> WithMetadataValue('Filename', 'readme'))" 
           Pack="true" PackagePath="%(Filename)%(Extension)" 
-          Condition="'$(PackageReadmeFile)' != ''" />
+          Condition="'$(PackReadme)' != 'false' and '$(PackageReadmeFile)' != ''" />
     
     <!-- src-level will need explicit inclusion -->
     <None Include="$(MSBuildThisFileDirectory)icon.png" Link="icon.png" Visible="false" 
           Pack="true" PackagePath="%(Filename)%(Extension)"
-          Condition="Exists('$(MSBuildThisFileDirectory)icon.png') and !Exists('$(MSBuildProjectDirectory)icon.png')" />
+          Condition="Exists('$(MSBuildThisFileDirectory)icon.png') and !Exists('$(MSBuildProjectDirectory)\icon.png')" />
 
     <None Include="$(MSBuildThisFileDirectory)readme.md" Link="readme.md"  
           Pack="true" PackagePath="%(Filename)%(Extension)"
-          Condition="Exists('$(MSBuildThisFileDirectory)readme.md') and !Exists('$(MSBuildProjectDirectory)readme.md')" />
+          Condition="'$(PackReadme)' != 'false' and Exists('$(MSBuildThisFileDirectory)readme.md') and !Exists('$(MSBuildProjectDirectory)\readme.md')" />
   </ItemGroup>
 
   <!-- Microsoft.NET.Sdk\targets\Microsoft.NET.DefaultAssemblyInfo.targets does this and is imported 


### PR DESCRIPTION
# devlooped/oss

- Append missing trailing path to directory for icon/readme https://github.com/devlooped/oss/commit/5cec43d
- Add .sass-cache to ignores https://github.com/devlooped/oss/commit/d65f9c7
- Move .sass-cache down alongside other jekyll folders https://github.com/devlooped/oss/commit/551d4e0
- Honor the PackReadme=false property https://github.com/devlooped/oss/commit/1bf1eac
- Ignore azure functions local settings https://github.com/devlooped/oss/commit/4bd7025
- Update dependabot.yml with some default groupings https://github.com/devlooped/oss/commit/cba10bb
- Add System.IdentityModel group https://github.com/devlooped/oss/commit/e7d18ae
- Add MS.IdentityModel to identity group https://github.com/devlooped/oss/commit/14d1868
- Exclude System.IdentityModel from System group https://github.com/devlooped/oss/commit/35ca3f3