### PR TITLE
Drop immutability which doesn't add any value

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -96,11 +96,8 @@ configuration level to use for persisting the value, by passing a `ConfigLevel`:
 //[vs "alias"]
 //	comexp = run|community|exp
 
-config = config.AddString("vs", "alias", "comexp", "run|community|exp", ConfigLevel.Global);
+config.AddString("vs", "alias", "comexp", "run|community|exp", ConfigLevel.Global);
 ```
-
-> IMPORTANT: the Config API is immutable, so if you make changes, you should update your reference
-> to the newly updated Config, otherwise, subsequent changes would override prior ones.
 
 You can explore the entire API in the [docs site](https://dotnetconfig.org/api/).
 

--- a/readme.md
+++ b/readme.md
@@ -324,11 +324,8 @@ configuration level to use for persisting the value, by passing a `ConfigLevel`:
 //[vs "alias"]
 //	comexp = run|community|exp
 
-config = config.AddString("vs", "alias", "comexp", "run|community|exp", ConfigLevel.Global);
+config.AddString("vs", "alias", "comexp", "run|community|exp", ConfigLevel.Global);
 ```
-
-> IMPORTANT: the Config API is immutable, so if you make changes, you should update your reference
-> to the newly updated Config, otherwise, subsequent changes would override prior ones.
 
 You can explore the entire API in the [docs site](https://dotnetconfig.org/api/).
 

--- a/src/Config.Tests/ConfigTests.cs
+++ b/src/Config.Tests/ConfigTests.cs
@@ -263,6 +263,21 @@ namespace DotNetConfig
         }
 
         [Fact]
+        public void when_setting_muliplevariables_then_can_reuse_instance()
+        {
+            var file = Path.GetTempFileName();
+            var config = Config.Build(file);
+
+            config.SetString("section", "subsection", "foo", "bar");
+            config.SetString("section", "subsection", "bar", "baz");
+
+            var saved = Config.Build(file);
+
+            Assert.Equal("bar", saved.GetString("section", "subsection", "foo"));
+            Assert.Equal("baz", saved.GetString("section", "subsection", "bar"));
+        }
+
+        [Fact]
         public void when_setting_global_variable_then_writes_global_file()
         {
             Config.GlobalLocation = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), ".netconfig");

--- a/src/Config/Config.cs
+++ b/src/Config/Config.cs
@@ -159,9 +159,9 @@ namespace DotNetConfig
         /// </summary>
         public ConfigLevel? Level =>
             this is AggregateConfig ? null :
-            FilePath == GlobalLocation ? (ConfigLevel?)ConfigLevel.Global :
-            FilePath == SystemLocation ? (ConfigLevel?)ConfigLevel.System :
-            FilePath.EndsWith(UserExtension) ? (ConfigLevel?)ConfigLevel.Local : null;
+            FilePath == GlobalLocation ? ConfigLevel.Global :
+            FilePath == SystemLocation ? ConfigLevel.System :
+            FilePath.EndsWith(UserExtension) ? ConfigLevel.Local : null;
 
         /// <summary>
         /// Gets the section and optional subsection from the configuration.

--- a/src/Config/Config.csproj
+++ b/src/Config/Config.csproj
@@ -7,8 +7,8 @@ Usage:
   var config = Config.Build();
   var value = config.GetString("section", "subsection", "variable");
 
-  // Setting values, Config is immutable, so chain calls and update var
-  config = config
+  // Setting values
+  config
     .SetString("section", "subsection", "variable", value)
     .SetBoolean("section", "subsection", "enabled", true);
 </Description>

--- a/src/Config/ConfigDocument.cs
+++ b/src/Config/ConfigDocument.cs
@@ -38,7 +38,7 @@ namespace DotNetConfig
 
         public ConfigLevel? Level { get; }
 
-        internal ImmutableList<Line> Lines { get; init; } = ImmutableList<Line>.Empty;
+        internal ImmutableList<Line> Lines { get; private set; } = ImmutableList<Line>.Empty;
 
         public ConfigDocument Save()
         {
@@ -99,7 +99,8 @@ namespace DotNetConfig
                 lines = lines.Insert(index, Line.CreateVariable(filePath, index, sectionLine.Section, sectionLine.Subsection, name, value));
             }
 
-            return this with { Lines = lines };
+            Lines = lines;
+            return this;
         }
 
         public ConfigDocument Set(string section, string? subsection, string name, string? value = null, ValueMatcher? valueMatcher = null)
@@ -119,7 +120,8 @@ namespace DotNetConfig
 
             if (variable != null)
             {
-                return this with { Lines = Lines.Replace(variable, variable.WithValue(value)) };
+                Lines = Lines.Replace(variable, variable.WithValue(value));
+                return this;
             }
             else
             {
@@ -143,7 +145,9 @@ namespace DotNetConfig
             var variable = variables.FirstOrDefault();
             if (variable != null)
             {
-                return (this with { Lines = Lines.Remove(variable) }).CleanupSection(section, subsection);
+                Lines = Lines.Remove(variable);
+                CleanupSection(section, subsection);
+                return this;
             }
 
             return this;
@@ -164,7 +168,8 @@ namespace DotNetConfig
                 lines = lines.Replace(variable, variable.WithValue(value));
             }
 
-            return this with { Lines = lines };
+            Lines = lines;
+            return this;
         }
 
         public ConfigDocument UnsetAll(string section, string? subsection, string name, ValueMatcher? valueMatcher = null)
@@ -185,7 +190,9 @@ namespace DotNetConfig
                 lines = lines.Remove(variable);
             }
 
-            return (this with { Lines = lines }).CleanupSection(section, subsection);
+            Lines = lines;
+            CleanupSection(section, subsection);
+            return this;
         }
 
         public ConfigDocument RemoveSection(string section, string? subsection = null)
@@ -216,7 +223,8 @@ namespace DotNetConfig
             while (lines.Count > 0 && lines[^1].Kind == LineKind.None)
                 lines = lines.RemoveAt(lines.Count - 1);
 
-            return this with { Lines = lines };
+            Lines = lines;
+            return this;
         }
 
         public ConfigDocument RenameSection(string oldSection, string? oldSubsection, string newSection, string? newSubsection)
@@ -246,7 +254,8 @@ namespace DotNetConfig
                 }
             }
 
-            return this with { Lines = lines };
+            Lines = lines;
+            return this;
         }
 
         /// <summary>
@@ -266,7 +275,8 @@ namespace DotNetConfig
                     while (index < lines.Count && lines[index].Kind == LineKind.None)
                         lines = lines.RemoveAt(index);
 
-                    return this with { Lines = lines };
+                    Lines = lines;
+                    return this;
                 }
             }
 

--- a/src/Config/FileConfig.cs
+++ b/src/Config/FileConfig.cs
@@ -20,32 +20,33 @@ namespace DotNetConfig
             if (value)
             {
                 // Shortcut notation.
-                return new FileConfig(FilePath,
-                    document.Add(section, subsection, variable, null)
-                            .Save());
+                document.Add(section, subsection, variable, null).Save();
             }
             else
             {
-                return new FileConfig(FilePath,
-                    document.Add(section, subsection, variable, "false")
-                            .Save());
+                document.Add(section, subsection, variable, "false").Save();
             }
+
+            return this;
         }
 
         public override Config AddDateTime(string section, string? subsection, string variable, DateTime value)
-            => new FileConfig(FilePath, document
-                .Add(section, subsection, variable, value.ToString("O"))
-                .Save());
+        {
+            document.Add(section, subsection, variable, value.ToString("O")).Save();
+            return this;
+        }
 
         public override Config AddNumber(string section, string? subsection, string variable, long value)
-            => new FileConfig(FilePath, document
-                .Add(section, subsection, variable, value.ToString())
-                .Save());
+        {
+            document.Add(section, subsection, variable, value.ToString()).Save();
+            return this;
+        }
 
         public override Config AddString(string section, string? subsection, string variable, string value)
-            => new FileConfig(FilePath, document
-                .Add(section, subsection, variable, value)
-                .Save());
+        {
+            document.Add(section, subsection, variable, value).Save();
+            return this;
+        }
 
         public override IEnumerable<ConfigEntry> GetAll(string section, string? subsection, string variable, string? valueRegex)
             => document.GetAll(section, subsection, variable, valueRegex);
@@ -69,78 +70,82 @@ namespace DotNetConfig
         }
 
         public override Config RemoveSection(string section, string? subsection)
-            => new FileConfig(FilePath, document
-                .RemoveSection(section, subsection)
-                .Save());
+        {
+            document.RemoveSection(section, subsection).Save();
+            return this;
+        }
 
         public override Config RenameSection(string oldSection, string? oldSubsection, string newSection, string? newSubsection)
-            => new FileConfig(FilePath, document
-                .RenameSection(oldSection, oldSubsection, newSection, newSubsection)
-                .Save());
+        {
+            document.RenameSection(oldSection, oldSubsection, newSection, newSubsection).Save();
+            return this;
+        }
 
         public override Config SetAllBoolean(string section, string? subsection, string variable, bool value, string? valueRegex)
         {
             if (value)
             {
                 // Shortcut notation.
-                return new FileConfig(FilePath, document
-                    .SetAll(section, subsection, variable, null, valueRegex)
-                    .Save());
+                document.SetAll(section, subsection, variable, null, valueRegex).Save();
             }
             else
             {
-                return new FileConfig(FilePath, document
-                    .SetAll(section, subsection, variable, "false", valueRegex)
-                    .Save());
+                document.SetAll(section, subsection, variable, "false", valueRegex).Save();
             }
+
+            return this;
         }
 
         public override Config SetAllDateTime(string section, string? subsection, string variable, DateTime value, string? valueRegex)
-            => new FileConfig(FilePath, document
-                .SetAll(section, subsection, variable, value.ToString("O"), valueRegex)
-                .Save());
+        {
+            document.SetAll(section, subsection, variable, value.ToString("O"), valueRegex).Save();
+            return this;
+        }
 
         public override Config SetAllNumber(string section, string? subsection, string variable, long value, string? valueRegex)
-            => new FileConfig(FilePath, document
-                .SetAll(section, subsection, variable, value.ToString(), valueRegex)
-                .Save());
+        {
+            document.SetAll(section, subsection, variable, value.ToString(), valueRegex).Save();
+            return this;
+        }
 
         public override Config SetAllString(string section, string? subsection, string variable, string value, string? valueRegex)
-            => new FileConfig(FilePath, document
-                .SetAll(section, subsection, variable, value, valueRegex)
-                .Save());
+        {
+            document.SetAll(section, subsection, variable, value, valueRegex).Save();
+            return this;
+        }
 
         public override Config SetBoolean(string section, string? subsection, string variable, bool value, string? valueRegex)
         {
             if (value)
             {
                 // Shortcut notation.
-                return new FileConfig(FilePath, document
-                    .Set(section, subsection, variable, null, valueRegex)
-                    .Save());
+                document.Set(section, subsection, variable, null, valueRegex).Save();
             }
             else
             {
-                return new FileConfig(FilePath, document
-                    .Set(section, subsection, variable, "false", valueRegex)
-                    .Save());
+                document.Set(section, subsection, variable, "false", valueRegex).Save();
             }
+
+            return this;
         }
 
         public override Config SetDateTime(string section, string? subsection, string variable, DateTime value, string? valueRegex)
-            => new FileConfig(FilePath, document
-                .Set(section, subsection, variable, value.ToString("O"), valueRegex)
-                .Save());
+        {
+            document.Set(section, subsection, variable, value.ToString("O"), valueRegex).Save();
+            return this;
+        }
 
         public override Config SetNumber(string section, string? subsection, string variable, long value, string? valueRegex)
-            => new FileConfig(FilePath, document
-                .Set(section, subsection, variable, value.ToString(), valueRegex)
-                .Save());
+        {
+            document.Set(section, subsection, variable, value.ToString(), valueRegex).Save();
+            return this;
+        }
 
         public override Config SetString(string section, string? subsection, string variable, string value, string? valueRegex)
-            => new FileConfig(FilePath, document
-                .Set(section, subsection, variable, value, valueRegex)
-                .Save());
+        {
+            document.Set(section, subsection, variable, value, valueRegex).Save();
+            return this;
+        }
 
         public override bool TryGetBoolean(string section, string? subsection, string variable, out bool value)
         {
@@ -211,14 +216,16 @@ namespace DotNetConfig
         }
 
         public override Config Unset(string section, string? subsection, string variable)
-            => new FileConfig(FilePath, document
-                .Unset(section, subsection, variable)
-                .Save());
+        {
+            document.Unset(section, subsection, variable).Save();
+            return this;
+        }
 
         public override Config UnsetAll(string section, string? subsection, string variable, string? valueMatcher)
-            => new FileConfig(FilePath, document
-                .UnsetAll(section, subsection, variable, valueMatcher)
-                .Save());
+        {
+            document.UnsetAll(section, subsection, variable, valueMatcher).Save();
+            return this;
+        }
 
         protected override IEnumerable<ConfigEntry> GetEntries() => document;
 


### PR DESCRIPTION
Config writing is such a rare occurrence (compared with reading) that the additional complexity of making the config/document immutable doesn't bring much value. Quite the contrary, it's a source of hard to detect bugs.

The pattern of returning the same object for chaining is preserved (so the API is backs-compat), and the mutability is compatible with how ServiceCollection works, for example. The chaining is just for convenience.